### PR TITLE
Add table for build system use

### DIFF
--- a/TABLE/tablesPEX.csv
+++ b/TABLE/tablesPEX.csv
@@ -1,0 +1,3 @@
+name
+PGMRND
+MACRND


### PR DESCRIPTION
Add table for FTL2JCL to read, and enable the z/OS UNIX based build system to work.
The table contains a list of the other csv tables in the TABLE directory.